### PR TITLE
moved reference to "RCTDeviceEventEmitter" to be required directly.  …

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Orientation = require('react-native').NativeModules.Orientation;
-var RCTDeviceEventEmitter = require('react-native').RCTDeviceEventEmitter;
+var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
 
 var listeners = {};
 var deviceEvent = "orientationDidChange";


### PR DESCRIPTION
…The RCT DeviceEventEmitter object doesn't seem to exist as a parameter in the react-native module (v0.9.0); but it certainly does as a stand-alone module.