### PR TITLE
Restore path to RCTDeviceEventEmitter

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
 var Orientation = require('react-native').NativeModules.Orientation;
-var RCTDeviceEventEmitter = require('RCTDeviceEventEmitter');
+var RCTDeviceEventEmitter = require('react-native').RCTDeviceEventEmitter;
 
 var listeners = {};
 var deviceEvent = "orientationDidChange";


### PR DESCRIPTION
This fixes Issue https://github.com/yamill/react-native-orientation/issues/6#issuecomment-144442760. Several people have been getting error messages since commit ce56ce656cc4d60cdc08fba0ad6965ef5ebd74cd was merged. This reverts that commit. Apparently things have changed since that commit fixed an issue. For the record, my environment is:

RN 0.11
Xcode 6.4
building with RN packager.