### PR TITLE
fix reload js crash

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -60,7 +60,6 @@ public class OrientationModule extends ReactContextBaseJavaModule {
 
             @Override
             public void onHostDestroy() {
-                activity.unregisterReceiver(receiver);
             }
         };
 


### PR DESCRIPTION
destroy always called after onPause. Unnecessary to unregister in onHostDestroy.
Crash happened when we trying to unregister receiver second time. closes #30 