### PR TITLE
Added new methods to provide specific orientation information

### DIFF
--- a/RCTOrientation/Orientation.m
+++ b/RCTOrientation/Orientation.m
@@ -88,12 +88,45 @@ static int _orientation = 3;
   return orientationStr;
 }
 
+- (NSString *)getSpecificOrientationStr: (UIDeviceOrientation)orientation {
+  NSString *orientationStr;
+  switch (orientation) {
+    case UIDeviceOrientationPortrait:
+      orientationStr = @"PORTRAIT";
+      break;
+
+    case UIDeviceOrientationLandscapeLeft:
+      orientationStr = @"LANDSCAPE-LEFT";
+      break;
+
+    case UIDeviceOrientationLandscapeRight:
+      orientationStr = @"LANDSCAPE-RIGHT";
+      break;
+
+    case UIDeviceOrientationPortraitUpsideDown:
+      orientationStr = @"PORTRAITUPSIDEDOWN";
+      break;
+
+    default:
+      orientationStr = @"UNKNOWN";
+      break;
+  }
+  return orientationStr;
+}
+
 RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(getOrientation:(RCTResponseSenderBlock)callback)
 {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   NSString *orientationStr = [self getOrientationStr:orientation];
+  callback(@[[NSNull null], orientationStr]);
+}
+
+RCT_EXPORT_METHOD(getSpecificOrientation:(RCTResponseSenderBlock)callback)
+{
+  UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+  NSString *orientationStr = [self getSpecificOrientationStr:orientation];
   callback(@[[NSNull null], orientationStr]);
 }
 
@@ -119,6 +152,30 @@ RCT_EXPORT_METHOD(lockToLandscape)
     [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeLeft] forKey:@"orientation"];
   }];
   
+}
+
+RCT_EXPORT_METHOD(lockToLandscapeRight)
+{
+  #if DEBUG
+    NSLog(@"Locked to Landscape Right");
+  #endif
+    [Orientation setOrientation:2];
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+        [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeLeft] forKey:@"orientation"];
+    }];
+
+}
+
+RCT_EXPORT_METHOD(lockToLandscapeLeft)
+{
+  #if DEBUG
+    NSLog(@"Locked to Landscape Left");
+  #endif
+  [Orientation setOrientation:2];
+  [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+    [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeRight] forKey:@"orientation"];
+  }];
+
 }
 
 RCT_EXPORT_METHOD(unlockAllOrientations)

--- a/index.js
+++ b/index.js
@@ -10,11 +10,22 @@ module.exports = {
       cb(error, orientation);
     });
   },
+  getSpecificOrientation(cb) {
+    Orientation.getSpecificOrientation((error,orientation) =>{
+      cb(error, orientation);
+    });
+  },
   lockToPortrait() {
     Orientation.lockToPortrait();
   },
   lockToLandscape() {
     Orientation.lockToLandscape();
+  },
+  lockToLandscapeRight() {
+    Orientation.lockToLandscapeRight();
+  },
+  lockToLandscapeLeft() {
+    Orientation.lockToLandscapeLeft();
   },
   unlockAllOrientations() {
     Orientation.unlockAllOrientations();


### PR DESCRIPTION
I'm submitting a PR to get landscape-left and landscape-right orientation functionality. This is added as a new method so as not to break compatibility with the existing API. Also added new methods to lock to landscape-left and lock to landscape-right.

A previous PR I submitted had similar functionality but it broke API. These new methods are an extension of the current API and should not cause any breakage in existing code out there using this package.

