### PR TITLE
Added specific orientation event listeners and updated the README

### DIFF
--- a/RCTOrientation/Orientation.m
+++ b/RCTOrientation/Orientation.m
@@ -50,19 +50,20 @@ static int _orientation = 3;
 
 }
 
-
 - (void)dealloc
 {
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
+
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
-
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
-  NSString *orientationStr = [self getOrientationStr:orientation];
+  [_bridge.eventDispatcher sendDeviceEventWithName:@"specificOrientationDidChange"
+                                              body:@{@"specificOrientation": [self getSpecificOrientationStr:orientation]}];
 
   [_bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange"
-                                              body:@{@"orientation": orientationStr}];
+                                              body:@{@"orientation": [self getOrientationStr:orientation]}];
+
 }
 
 - (NSString *)getOrientationStr: (UIDeviceOrientation)orientation {

--- a/README.md
+++ b/README.md
@@ -110,17 +110,27 @@ Whenever you want to use it within React Native code now you can:
 ## Events
 
 - `addOrientationListener(function(orientation))`
+
+orientation can return either `LANDSCAPE` `PORTRAIT` `UNKNOWN`
+also `PORTRAITUPSIDEDOWN` is now different from `PORTRAIT`
+
 - `removeOrientationListener(function(orientation))`
 
 ## Functions
 
 - `lockToPortrait()`
 - `lockToLandscape()`
+- `lockToLandscapeLeft()`
+- `lockToLandscapeRight()`
 - `unlockAllOrientations()`
 - `getOrientation(function(err, orientation)`
 
-orientation can return either `LANDSCAPE` `PORTRAIT` `UNKNOWN`
-also 'PORTRAITUPSIDEDOWN' is now different from PORTRAIT
+orientation can return either `LANDSCAPE` `PORTRAIT` `UNKNOWN` `PORTRAITUPSIDEDOWN`
+
+- `getSpecificOrientation(function(err, specificOrientation)`
+
+specificOrientation can return either `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT` `PORTRAIT` `UNKNOWN` `PORTRAITUPSIDEDOWN`
+
 ## TODOS
 
 - [x] Add some way to allow setting a preferred orientation on a screen by screen basis.

--- a/README.md
+++ b/README.md
@@ -116,6 +116,12 @@ also `PORTRAITUPSIDEDOWN` is now different from `PORTRAIT`
 
 - `removeOrientationListener(function(orientation))`
 
+- `addSpecificOrientationListener(function(specificOrientation))`
+
+specificOrientation can return either `LANDSCAPE-LEFT` `LANDSCAPE-RIGHT` `PORTRAIT` `UNKNOWN` `PORTRAITUPSIDEDOWN`
+
+- `removeSpecificOrientationListener(function(specificOrientation))`
+
 ## Functions
 
 - `lockToPortrait()`

--- a/index.js
+++ b/index.js
@@ -2,7 +2,8 @@ var Orientation = require('react-native').NativeModules.Orientation;
 var DeviceEventEmitter = require('react-native').DeviceEventEmitter;
 
 var listeners = {};
-var deviceEvent = "orientationDidChange";
+var orientationDidChangeEvent = "orientationDidChange";
+var specificOrientationDidChangeEvent = "specificOrientationDidChange";
 
 module.exports = {
   getOrientation(cb) {
@@ -31,12 +32,25 @@ module.exports = {
     Orientation.unlockAllOrientations();
   },
   addOrientationListener(cb) {
-    listeners[cb] = DeviceEventEmitter.addListener(deviceEvent,
+    listeners[cb] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
       (body) => {
         cb(body.orientation);
       });
   },
   removeOrientationListener(cb) {
+    if (!listeners[cb]) {
+      return;
+    }
+    listeners[cb].remove();
+    listeners[cb] = null;
+  },
+  addSpecificOrientationListener(cb) {
+    listeners[cb] = DeviceEventEmitter.addListener(specificOrientationDidChangeEvent,
+      (body) => {
+        cb(body.specificOrientation);
+      });
+  },
+  removeSpecificOrientationListener(cb) {
     if (!listeners[cb]) {
       return;
     }


### PR DESCRIPTION
I was using a hackish way to get specific orientation when the orientation listener returned orientation === LANDSCAPE. It's clearer to just use a specific orientation listener, so I added that.

I updated the README with the new specific orientation methods.

Thanks for the quick review & merge on my previous PR!