### PR TITLE
Avoid invoking the catalyst before available

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -43,10 +43,11 @@ public class OrientationModule extends ReactContextBaseJavaModule {
 
                 WritableMap params = Arguments.createMap();
                 params.putString("orientation", orientationValue);
-
-                ctx
+                if (ctx.hasActiveCatalystInstance()) {
+                    ctx
                         .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
                         .emit("orientationDidChange", params);
+                }
             }
         };
 


### PR DESCRIPTION
Fix https://github.com/yamill/react-native-orientation/issues/34