### PR TITLE
Specific locks

### DIFF
--- a/RCTOrientation/Orientation.m
+++ b/RCTOrientation/Orientation.m
@@ -134,11 +134,19 @@ RCT_EXPORT_METHOD(lockToLandscape)
   #if DEBUG
     NSLog(@"Locked to Landscape");
   #endif
-  [Orientation setOrientation:UIInterfaceOrientationMaskLandscape];
-  [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
-    [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeLeft] forKey:@"orientation"];
-  }];
-  
+  UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
+  NSString *orientationStr = [self getSpecificOrientationStr:orientation];
+  if ([orientationStr isEqualToString:@"LANDSCAPE-LEFT"]) {
+    [Orientation setOrientation:UIInterfaceOrientationMaskLandscape];
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+      [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeRight] forKey:@"orientation"];
+    }];
+  } else {
+    [Orientation setOrientation:UIInterfaceOrientationMaskLandscape];
+    [[NSOperationQueue mainQueue] addOperationWithBlock:^ {
+      [[UIDevice currentDevice] setValue:[NSNumber numberWithInteger: UIInterfaceOrientationLandscapeLeft] forKey:@"orientation"];
+    }];
+  }
 }
 
 RCT_EXPORT_METHOD(lockToLandscapeRight)

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -109,7 +109,17 @@ public class OrientationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void lockToLandscape() {
+      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+    }
+
+    @ReactMethod
+    public void lockToLandscapeLeft() {
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+    }
+
+    @ReactMethod
+    public void lockToLandscapeRight() {
+      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
     }
 
     @ReactMethod


### PR DESCRIPTION
This pull request aims at solving this edge case: 
A user is already holding the device in landscape.
What happens now is that if he is in landscapeRight mode, the app will flip to landscapeLeft and the user has to flip the phone.
What i did:
1) Android: Added specific landscapeOrientationLocks.
2) Android: Change the lockToLandscape to be sensor_landscape, which means it will accept either direction of landscape as valid.
3) iOS: when locking, check the orientation, if its already landscape then lock to the direction the phone is in.