### PR TITLE
Podspec

### DIFF
--- a/RCTOrientation.podspec
+++ b/RCTOrientation.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "RCTOrientation"
+  s.version      = "1.15.0"
+  s.summary      = "Listen to device orientation changes in react-native."
+  s.requires_arc = true
+  s.author       = { 'Yamill Vallecillo' => 'yamill@gmail.com' }
+  s.homepage     = 'https://github.com/xinthink/react-native-material-kit'
+  s.source       = { :git => "https://github.com/yamill/react-native-orientation.git" }
+  s.source_files = 'RCTOrientation/*'
+  s.platform     = :ios, "7.0"
+  s.dependency 'React'
+end

--- a/RCTOrientation.podspec
+++ b/RCTOrientation.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "RCTOrientation"
-  s.version      = "1.15.0"
+  s.version      = "1.16.0"
   s.summary      = "Listen to device orientation changes in react-native."
   s.requires_arc = true
   s.author       = { 'Yamill Vallecillo' => 'yamill@gmail.com' }

--- a/RCTOrientation/AppDelegate.h
+++ b/RCTOrientation/AppDelegate.h
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2015-present, Facebook, Inc.
+ * All rights reserved.
+ *
+ * This source code is licensed under the BSD-style license found in the
+ * LICENSE file in the root directory of this source tree. An additional grant
+ * of patent rights can be found in the PATENTS file in the same directory.
+ */
+
+#import <UIKit/UIKit.h>
+
+@interface AppDelegate : UIResponder <UIApplicationDelegate>
+
+@property (nonatomic, strong) UIWindow *window;
+
+@end

--- a/react-native-orientation.podspec
+++ b/react-native-orientation.podspec
@@ -1,10 +1,10 @@
 Pod::Spec.new do |s|
-  s.name         = "RCTOrientation"
+  s.name         = "react-native-orientation"
   s.version      = "1.16.0"
   s.summary      = "Listen to device orientation changes in react-native."
   s.requires_arc = true
   s.author       = { 'Yamill Vallecillo' => 'yamill@gmail.com' }
-  s.homepage     = 'https://github.com/xinthink/react-native-material-kit'
+  s.homepage     = 'https://github.com/yamill/react-native-orientation'
   s.source       = { :git => "https://github.com/yamill/react-native-orientation.git" }
   s.source_files = 'RCTOrientation/*'
   s.platform     = :ios, "7.0"


### PR DESCRIPTION
Fixes #49 

I was getting a build error until I added the `AppDelegate.h` file, but its contents are straight out of a `react-native init` project, so I'm not sure that this is syntactically the best way to go when loading the ObjC code via CocoaPods.

If someone with more Xcode experience could chime in, here, I'd appreciate it.