### PR TITLE
Android: Enable orientation events when locking orientation + added specific orientation support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,18 +54,6 @@ Run `npm install react-native-orientation --save`
     }
     ```
 
-4. Implement onConfigurationChanged method (in MainActivity.java)
-
-```
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
-        super.onConfigurationChanged(newConfig);
-        Intent intent = new Intent("onConfigurationChanged");
-        intent.putExtra("newConfig", newConfig);
-        this.sendBroadcast(intent);
-    }
-```
-
 Whenever you want to use it within React Native code now you can:
 `var Orientation = require('react-native-orientation');`
 

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -43,6 +43,7 @@ public class OrientationModule extends ReactContextBaseJavaModule {
     public static final String PORTRAIT_UPSIDEDOWN = "PORTRAITUPSIDEDOWN";
     public static final String ORIENTATION_UNKNOWN = "UNKNOWN";
 
+    private static final int ACTIVE_SECTOR_SIZE = 45;
     private final String[] ORIENTATIONS_PORTRAIT_DEVICE = {PORTRAIT, LANDSCAPE_RIGHT, PORTRAIT_UPSIDEDOWN, LANDSCAPE_LEFT};
     private final String[] ORIENTATIONS_LANDSCAPE_DEVICE = {LANDSCAPE_LEFT, PORTRAIT, LANDSCAPE_RIGHT, PORTRAIT_UPSIDEDOWN};
 
@@ -62,6 +63,15 @@ public class OrientationModule extends ReactContextBaseJavaModule {
                 if (isDeviceOrientationLocked() || !ctx.hasActiveCatalystInstance()) return;
 
                 mOrientationValue = orientationValue;
+
+                if (mOrientation != null && mSpecificOrientation != null) {
+                    final int halfSector = ACTIVE_SECTOR_SIZE / 2;
+                    if ((orientationValue % 90) > halfSector
+                        && (orientationValue % 90) < (90 - halfSector)) {
+                        return;
+                    }
+                }
+
                 final String orientation = getOrientationString(orientationValue);
                 final String specificOrientation = getSpecificOrientationString(orientationValue);
 

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -37,8 +37,6 @@ public class OrientationModule extends ReactContextBaseJavaModule {
     private String mSpecificOrientation;
     final private String[] mOrientations;
 
-    private boolean mHostActive = false;
-
     public static final String LANDSCAPE = "LANDSCAPE";
     public static final String LANDSCAPE_LEFT = "LANDSCAPE-LEFT";
     public static final String LANDSCAPE_RIGHT = "LANDSCAPE-RIGHT";
@@ -61,9 +59,6 @@ public class OrientationModule extends ReactContextBaseJavaModule {
         reactContext.addLifecycleEventListener(mLifecycleEventListener);
 
         mOrientationEventListener = createOrientationEventListener(reactContext);
-        if (mOrientationEventListener.canDetectOrientation()) {
-            mOrientationEventListener.enable();
-        }
     }
 
     private OrientationEventListener createOrientationEventListener(final ReactApplicationContext reactContext) {
@@ -71,7 +66,7 @@ public class OrientationModule extends ReactContextBaseJavaModule {
             SensorManager.SENSOR_DELAY_NORMAL) {
             @Override
             public void onOrientationChanged(int orientationValue) {
-                if (!mHostActive || isDeviceOrientationLocked() || !reactContext.hasActiveCatalystInstance()) return;
+                if (isDeviceOrientationLocked() || !reactContext.hasActiveCatalystInstance()) return;
 
                 mOrientationValue = orientationValue;
 
@@ -110,17 +105,19 @@ public class OrientationModule extends ReactContextBaseJavaModule {
         return new LifecycleEventListener() {
             @Override
             public void onHostResume() {
-                mHostActive = true;
+                if (mOrientationEventListener.canDetectOrientation()) {
+                    mOrientationEventListener.enable();
+                }
             }
 
             @Override
             public void onHostPause() {
-                mHostActive = false;
+                mOrientationEventListener.disable();
             }
 
             @Override
             public void onHostDestroy() {
-                mHostActive = false;
+                mOrientationEventListener.disable();
             }
         };
     }


### PR DESCRIPTION
This PR uses orientation event listener for Android instead of the onConfigurationChanged approach that is currently used in master. The benefits of this approach is that orientation events will still be sent even if you lock a view to a certain orientation, which make the Android version behave similar to iOS version. Another benefit is that the `onConfiguration` code in `MainActivity.java` is no longer needed.

Also implemented specific orientation for android so that both platforms now support this.
