### PR TITLE
Support RNPM, CocoaPods, react-native > 0.25

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,28 @@
+# OSX
+#
+.DS_Store
+
+# Xcode
+#
+build/
+*.pbxuser
+!default.pbxuser
+*.mode1v3
+!default.mode1v3
+*.mode2v3
+!default.mode2v3
+*.perspectivev3
+!default.perspectivev3
+xcuserdata
+*.xccheckout
+*.moved-aside
+DerivedData
+*.hmap
+*.ipa
+*.xcuserstate
+project.xcworkspace
+
+# node.js
+#
+node_modules/
+npm-debug.log

--- a/RCTOrientation/Orientation.h
+++ b/RCTOrientation/Orientation.h
@@ -7,13 +7,8 @@
 #import "RCTBridgeModule.h"
 #import "RCTBridge.h"
 #import "RCTEventDispatcher.h"
-#import "AppDelegate.h"
 
 @interface Orientation : NSObject <RCTBridgeModule>
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;
 + (UIInterfaceOrientationMask)getOrientation;
-@end
-
-@interface AppDelegate (Orientation)
-
 @end

--- a/RCTOrientation/Orientation.m
+++ b/RCTOrientation/Orientation.m
@@ -3,17 +3,6 @@
 //
 
 #import "Orientation.h"
-#import "AppDelegate.h"
-
-
-@implementation AppDelegate (Orientation)
-
-- (NSUInteger)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
-  return [Orientation getOrientation];
-}
-
-@end
-
 
 @implementation Orientation
 

--- a/README.md
+++ b/README.md
@@ -1,24 +1,46 @@
 ## react-native-orientation
 Listen to device orientation changes in react-native and set preferred orientation on screen to screen basis.
 
-### Add it to your project
+### Installation
+
+#### via rnpm
+
+Run `rnpm install react-native-orientation`
+
+> Note: rnpm will install and link the library automatically.
+
+#### via npm
 
 Run `npm install react-native-orientation --save`
 
+### Linking
 
-#### iOS
+#### Using rnpm (iOS + Android)
 
-1. Open your project in XCode, right click on your project and click `Add Files to "Your Project Name"`
-2. Add `RCTOrientation` folder from your `node_modules/react-native-orientation` folder. <b>Make sure you have 'Create Groups' selected</b>
+`rnpm link react-native-orientation`
 
-#### Android
+#### Using [CocoaPods](https://cocoapods.org) (iOS Only)
+
+`pod 'react-native-orientation', :path => 'node_modules/react-native-orientation'`
+
+Consult the React Native documentation on how to [install React Native using CocoaPods](https://facebook.github.io/react-native/docs/embedded-app-ios.html#install-react-native-using-cocoapods).
+
+#### Manually
+
+**iOS**
+
+1. Add `node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj` to your xcode project, usually under the `Libraries` group
+1. Add `libRCTOrientation.a` (from `Products` under `RCTOrientation.xcodeproj`) to build target's `Linked Frameworks and Libraries` list
+
+
+**Android**
 
 1. In `android/setting.gradle`
 
     ```
     ...
-    include ':Orientation', ':app'
-    project(':Orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')
+    include ':react-native-orientation', ':app'
+    project(':react-native-orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')
     ```
 
 2. In `android/app/build.gradle`
@@ -27,18 +49,16 @@ Run `npm install react-native-orientation --save`
     ...
     dependencies {
         ...
-        compile project(':Orientation')
+        compile project(':react-native-orientation')
     }
     ```
 
 3. Register module (in MainActivity.java)
 
     ```
-    import android.content.Intent; // <--- import
-    import android.content.res.Configuration; // <--- import
     import com.github.yamill.orientation.OrientationPackage;  // <--- import
 
-    public class MainActivity extends Activity implements DefaultHardwareBackBtnHandler {
+    public class MainActivity extends ReactActivity {
       ......
 
       @Override
@@ -54,23 +74,53 @@ Run `npm install react-native-orientation --save`
     }
     ```
 
-4. Implement onConfigurationChanged method (in MainActivity.java)
+### Configuration
+
+#### iOS
+
+Add the following to your project's `AppDelegate.m`:
+
+>Note: This AppDelegate implementation should be added in addition to the existing one, not replace/modify it.
+
+```objc
+#import "Orientation.h" // <--- import
+
+@implementation AppDelegate (Orientation) // <--- receives Orientation
+
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+  return [Orientation getOrientation];
+}
+
+@end
+```
+
+#### Android
+
+Implement onConfigurationChanged method (in MainActivity.java)
 
 ```
-    @Override
-    public void onConfigurationChanged(Configuration newConfig) {
+    import android.content.Intent; // <--- import
+    import android.content.res.Configuration; // <--- import
+
+    public class MainActivity extends ReactActivity {
+      ......
+      @Override
+      public void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
         Intent intent = new Intent("onConfigurationChanged");
         intent.putExtra("newConfig", newConfig);
         this.sendBroadcast(intent);
     }
+
+      ......
+
+    }
 ```
+
+## Usage
 
 Whenever you want to use it within React Native code now you can:
 `var Orientation = require('react-native-orientation');`
-
-
-## Usage
 
 ```javascript
   _orientationDidChange: function(orientation) {
@@ -103,9 +153,9 @@ Whenever you want to use it within React Native code now you can:
   },
 
   componentWillUnmount: function() {
-	Orientation.getOrientation((err,orientation)=> {
-		console.log("Current Device Orientation: ", orientation);
-	});
+    Orientation.getOrientation((err,orientation)=> {
+      console.log("Current Device Orientation: ", orientation);
+    });
     Orientation.removeOrientationListener(this._orientationDidChange);
   }
 ```

--- a/README.md
+++ b/README.md
@@ -80,16 +80,16 @@ Consult the React Native documentation on how to [install React Native using Coc
 
 Add the following to your project's `AppDelegate.m`:
 
->Note: This AppDelegate implementation should be added in addition to the existing one, not replace/modify it.
-
 ```objc
 #import "Orientation.h" // <--- import
 
-@implementation AppDelegate (Orientation) // <--- receives Orientation
+@implementation AppDelegate
 
-- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
-  return [Orientation getOrientation];
-}
+  // ...
+
+  - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+    return [Orientation getOrientation];
+  }
 
 @end
 ```

--- a/demo/.flowconfig
+++ b/demo/.flowconfig
@@ -15,8 +15,6 @@
 # Ignore react and fbjs where there are overlaps, but don't ignore
 # anything that react-native relies on
 .*/node_modules/fbjs/lib/Map.js
-.*/node_modules/fbjs/lib/fetch.js
-.*/node_modules/fbjs/lib/ExecutionEnvironment.js
 .*/node_modules/fbjs/lib/ErrorUtils.js
 
 # Flow has a built-in definition for the 'react' module which we prefer to use
@@ -47,6 +45,9 @@
 
 # Ignore BUCK generated folders
 .*\.buckd/
+
+# Ignore RNPM
+.*/local-cli/rnpm/.*
 
 .*/node_modules/is-my-json-valid/test/.*\.json
 .*/node_modules/iconv-lite/encodings/tables/.*\.json
@@ -82,15 +83,15 @@ esproposal.class_instance_fields=enable
 munge_underscores=true
 
 module.name_mapper='^image![a-zA-Z0-9$_-]+$' -> 'GlobalImageStub'
-module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\)$' -> 'RelativeImageStub'
+module.name_mapper='^[./a-zA-Z0-9$_-]+\.\(bmp\|gif\|jpg\|jpeg\|png\|psd\|svg\|webp\|m4v\|mov\|mp4\|mpeg\|mpg\|webm\|aac\|aiff\|caf\|m4a\|mp3\|wav\|html\|pdf\)$' -> 'RelativeImageStub'
 
 suppress_type=$FlowIssue
 suppress_type=$FlowFixMe
 suppress_type=$FixMe
 
-suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
-suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-2]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
+suppress_comment=\\(.\\|\n\\)*\\$FlowFixMe\\($\\|[^(]\\|(\\(>=0\\.\\(2[0-5]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)
+suppress_comment=\\(.\\|\n\\)*\\$FlowIssue\\((\\(>=0\\.\\(2[0-5]\\|1[0-9]\\|[0-9]\\).[0-9]\\)? *\\(site=[a-z,_]*react_native[a-z,_]*\\)?)\\)?:? #[0-9]+
 suppress_comment=\\(.\\|\n\\)*\\$FlowFixedInNextDeploy
 
 [version]
-^0.22.0
+^0.25.0

--- a/demo/android/app/BUCK
+++ b/demo/android/app/BUCK
@@ -5,7 +5,7 @@ import re
 # - install Buck
 # - `npm start` - to start the packager
 # - `cd android`
-# - `cp ~/.android/debug.keystore keystores/debug.keystore`
+# - `keytool -genkey -v -keystore keystores/debug.keystore -storepass android -alias androiddebugkey -keypass android -dname "CN=Android Debug,O=Android,C=US`
 # - `./gradlew :app:copyDownloadableDepsToLibs` - make all Gradle compile dependencies available to Buck
 # - `buck install -r android/app` - compile, install and run application
 #

--- a/demo/android/app/build.gradle
+++ b/demo/android/app/build.gradle
@@ -120,10 +120,10 @@ android {
 }
 
 dependencies {
+    compile project(':react-native-orientation')
     compile fileTree(dir: "libs", include: ["*.jar"])
     compile "com.android.support:appcompat-v7:23.0.1"
     compile "com.facebook.react:react-native:+"  // From node_modules
-    compile project(':Orientation')
 }
 
 // Run this once to be able to run the application with BUCK

--- a/demo/android/app/proguard-rules.pro
+++ b/demo/android/app/proguard-rules.pro
@@ -51,9 +51,9 @@
 
 -keepattributes Signature
 -keepattributes *Annotation*
--keep class com.squareup.okhttp.** { *; }
--keep interface com.squareup.okhttp.** { *; }
--dontwarn com.squareup.okhttp.**
+-keep class okhttp3.** { *; }
+-keep interface okhttp3.** { *; }
+-dontwarn okhttp3.**
 
 # okio
 
@@ -61,7 +61,3 @@
 -dontwarn java.nio.file.*
 -dontwarn org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement
 -dontwarn okio.**
-
-# stetho
-
--dontwarn com.facebook.stetho.**

--- a/demo/android/app/src/main/java/com/demo/MainActivity.java
+++ b/demo/android/app/src/main/java/com/demo/MainActivity.java
@@ -2,9 +2,9 @@ package com.demo;
 
 import android.content.Intent;
 import android.content.res.Configuration;
-import com.github.yamill.orientation.OrientationPackage;
 
 import com.facebook.react.ReactActivity;
+import com.github.yamill.orientation.OrientationPackage;
 import com.facebook.react.ReactPackage;
 import com.facebook.react.shell.MainReactPackage;
 

--- a/demo/android/app/src/main/res/values/strings.xml
+++ b/demo/android/app/src/main/res/values/strings.xml
@@ -1,3 +1,5 @@
 <resources>
+
+
     <string name="app_name">demo</string>
 </resources>

--- a/demo/android/settings.gradle
+++ b/demo/android/settings.gradle
@@ -1,4 +1,5 @@
 rootProject.name = 'demo'
 
-include ':Orientation', ':app'
-project(':Orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')
+include ':app'
+include ':react-native-orientation'
+project(':react-native-orientation').projectDir = new File(rootProject.projectDir, '../node_modules/react-native-orientation/android')

--- a/demo/index.android.js
+++ b/demo/index.android.js
@@ -1,6 +1,6 @@
-import React, {
+import React, { Component } from 'react';
+import {
   AppRegistry,
-  Component,
   StyleSheet,
   Text,
   TouchableOpacity,

--- a/demo/index.ios.js
+++ b/demo/index.ios.js
@@ -1,6 +1,6 @@
-import React, {
+import React, { Component } from 'react';
+import {
   AppRegistry,
-  Component,
   StyleSheet,
   Text,
   TouchableOpacity,

--- a/demo/index.ios.js
+++ b/demo/index.ios.js
@@ -16,17 +16,24 @@ class demo extends Component {
     this.state = {
       init,
       or: init,
+      sor: init,
     };
     this._updateOrientation = this._updateOrientation.bind(this);
     Orientation.addOrientationListener(this._updateOrientation);
+    this._updateSpecificOrientation = this._updateSpecificOrientation.bind(this);
+    Orientation.addSpecificOrientationListener(this._updateSpecificOrientation);
   }
 
   _updateOrientation(or) {
     this.setState({ or });
   }
 
+  _updateSpecificOrientation(sor) {
+    this.setState({ sor });
+  }
+
   render() {
-    const { init, or} = this.state;
+    const { init, or, sor} = this.state;
     return (
       <View style={styles.container}>
         <Text style={styles.welcome}>
@@ -37,6 +44,9 @@ class demo extends Component {
         </Text>
         <Text style={styles.instructions}>
           {`Current Orientation: ${or}`}
+        </Text>
+        <Text style={styles.instructions}>
+          {`Specific Orientation: ${sor}`}
         </Text>
         <TouchableOpacity
           onPress={Orientation.unlockAllOrientations}
@@ -54,14 +64,32 @@ class demo extends Component {
             Lock To Portrait
           </Text>
         </TouchableOpacity>
-        <TouchableOpacity
-          onPress={Orientation.lockToLandscape}
-          style={styles.button}
-        >
-          <Text style={styles.instructions}>
-            Lock To Landscape
-          </Text>
-        </TouchableOpacity>
+        <View style={styles.buttonContainer}>
+          <TouchableOpacity
+            onPress={Orientation.lockToLandscapeLeft}
+            style={styles.button}
+          >
+            <Text style={styles.instructions}>
+              Lock To Left
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={Orientation.lockToLandscape}
+            style={styles.button}
+          >
+            <Text style={styles.instructions}>
+              Lock To Landscape
+            </Text>
+          </TouchableOpacity>
+          <TouchableOpacity
+            onPress={Orientation.lockToLandscapeRight}
+            style={styles.button}
+          >
+            <Text style={styles.instructions}>
+              Lock To Right
+            </Text>
+          </TouchableOpacity>
+        </View>
       </View>
     );
   }
@@ -83,6 +111,11 @@ const styles = StyleSheet.create({
     textAlign: 'center',
     color: '#333333',
     marginBottom: 5,
+  },
+  buttonContainer: {
+    flex: 0,
+    flexDirection: 'row',
+    justifyContent: 'space-around'
   },
   button: {
     padding: 5,

--- a/demo/ios/demo.xcodeproj/project.pbxproj
+++ b/demo/ios/demo.xcodeproj/project.pbxproj
@@ -21,8 +21,8 @@
 		13B07FBF1A68108700A75B9A /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 13B07FB51A68108700A75B9A /* Images.xcassets */; };
 		13B07FC11A68108700A75B9A /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 13B07FB71A68108700A75B9A /* main.m */; };
 		146834051AC3E58100842450 /* libReact.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 146834041AC3E56700842450 /* libReact.a */; };
-		20E059E41CD60CB100089ED7 /* Orientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 20E059E31CD60CB100089ED7 /* Orientation.m */; };
 		832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 832341B51AAA6A8300B99B32 /* libRCTText.a */; };
+		93BA1B749E064516BDD8CCEC /* libRCTOrientation.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8247B4A7E88A43F6A545CC26 /* libRCTOrientation.a */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +89,13 @@
 			remoteGlobalIDString = 83CBBA2E1A601D0E00E9B192;
 			remoteInfo = React;
 		};
+		270BC5321D0E1CB20071D1C4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 563D5526E5054D96A6AAB8A6 /* RCTOrientation.xcodeproj */;
+			proxyType = 2;
+			remoteGlobalIDString = 134814201AA4EA6300B7C361;
+			remoteInfo = RCTOrientation;
+		};
 		78C398B81ACF4ADC00677621 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */;
@@ -125,9 +132,9 @@
 		13B07FB61A68108700A75B9A /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = Info.plist; path = demo/Info.plist; sourceTree = "<group>"; };
 		13B07FB71A68108700A75B9A /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = main.m; path = demo/main.m; sourceTree = "<group>"; };
 		146833FF1AC3E56700842450 /* React.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = React.xcodeproj; path = "../node_modules/react-native/React/React.xcodeproj"; sourceTree = "<group>"; };
-		20E059E21CD60CB100089ED7 /* Orientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Orientation.h; sourceTree = "<group>"; };
-		20E059E31CD60CB100089ED7 /* Orientation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Orientation.m; sourceTree = "<group>"; };
+		563D5526E5054D96A6AAB8A6 /* RCTOrientation.xcodeproj */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = "wrapper.pb-project"; name = RCTOrientation.xcodeproj; path = "../node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj"; sourceTree = "<group>"; };
 		78C398B01ACF4ADC00677621 /* RCTLinking.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTLinking.xcodeproj; path = "../node_modules/react-native/Libraries/LinkingIOS/RCTLinking.xcodeproj"; sourceTree = "<group>"; };
+		8247B4A7E88A43F6A545CC26 /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = undefined; fileEncoding = 9; includeInIndex = 0; lastKnownFileType = archive.ar; path = libRCTOrientation.a; sourceTree = "<group>"; };
 		832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.pb-project"; name = RCTText.xcodeproj; path = "../node_modules/react-native/Libraries/Text/RCTText.xcodeproj"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -153,6 +160,7 @@
 				832341BD1AAA6AB300B99B32 /* libRCTText.a in Frameworks */,
 				00C302EA1ABCBA2D00DB3ED1 /* libRCTVibration.a in Frameworks */,
 				139FDEF61B0652A700C62182 /* libRCTWebSocket.a in Frameworks */,
+				93BA1B749E064516BDD8CCEC /* libRCTOrientation.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -254,14 +262,12 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		20E059E11CD60CB100089ED7 /* RCTOrientation */ = {
+		270BC52A1D0E1CB20071D1C4 /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				20E059E21CD60CB100089ED7 /* Orientation.h */,
-				20E059E31CD60CB100089ED7 /* Orientation.m */,
+				270BC5331D0E1CB20071D1C4 /* libRCTOrientation.a */,
 			);
-			name = RCTOrientation;
-			path = "../node_modules/react-native-orientation/RCTOrientation";
+			name = Products;
 			sourceTree = "<group>";
 		};
 		78C398B11ACF4ADC00677621 /* Products */ = {
@@ -285,6 +291,7 @@
 				832341B01AAA6A8300B99B32 /* RCTText.xcodeproj */,
 				00C302DF1ABCB9EE00DB3ED1 /* RCTVibration.xcodeproj */,
 				139FDEE61B06529A00C62182 /* RCTWebSocket.xcodeproj */,
+				563D5526E5054D96A6AAB8A6 /* RCTOrientation.xcodeproj */,
 			);
 			name = Libraries;
 			sourceTree = "<group>";
@@ -300,7 +307,6 @@
 		83CBB9F61A601CBA00E9B192 = {
 			isa = PBXGroup;
 			children = (
-				20E059E11CD60CB100089ED7 /* RCTOrientation */,
 				13B07FAE1A68108700A75B9A /* demo */,
 				832341AE1AAA6A7D00B99B32 /* Libraries */,
 				00E356EF1AD99517003FC87E /* demoTests */,
@@ -364,7 +370,7 @@
 		83CBB9F71A601CBA00E9B192 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 610;
 				ORGANIZATIONNAME = Facebook;
 				TargetAttributes = {
 					00E356ED1AD99517003FC87E = {
@@ -404,6 +410,10 @@
 				{
 					ProductGroup = 00C302D41ABCB9D200DB3ED1 /* Products */;
 					ProjectRef = 00C302D31ABCB9D200DB3ED1 /* RCTNetwork.xcodeproj */;
+				},
+				{
+					ProductGroup = 270BC52A1D0E1CB20071D1C4 /* Products */;
+					ProjectRef = 563D5526E5054D96A6AAB8A6 /* RCTOrientation.xcodeproj */;
 				},
 				{
 					ProductGroup = 139105B71AF99BAD00B5F7CC /* Products */;
@@ -491,6 +501,13 @@
 			remoteRef = 146834031AC3E56700842450 /* PBXContainerItemProxy */;
 			sourceTree = BUILT_PRODUCTS_DIR;
 		};
+		270BC5331D0E1CB20071D1C4 /* libRCTOrientation.a */ = {
+			isa = PBXReferenceProxy;
+			fileType = archive.ar;
+			path = libRCTOrientation.a;
+			remoteRef = 270BC5321D0E1CB20071D1C4 /* PBXContainerItemProxy */;
+			sourceTree = BUILT_PRODUCTS_DIR;
+		};
 		78C398B91ACF4ADC00677621 /* libRCTLinking.a */ = {
 			isa = PBXReferenceProxy;
 			fileType = archive.ar;
@@ -558,7 +575,6 @@
 			files = (
 				13B07FBC1A68108700A75B9A /* AppDelegate.m in Sources */,
 				13B07FC11A68108700A75B9A /* main.m in Sources */,
-				20E059E41CD60CB100089ED7 /* Orientation.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -589,10 +605,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
@@ -600,6 +612,10 @@
 				INFOPLIST_FILE = demoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/demo.app/demo";
 			};
@@ -610,13 +626,13 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				COPY_PHASE_STRIP = NO;
-				FRAMEWORK_SEARCH_PATHS = (
-					"$(SDKROOT)/Developer/Library/Frameworks",
-					"$(inherited)",
-				);
 				INFOPLIST_FILE = demoTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.2;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"\"$(SRCROOT)/$(TARGET_NAME)\"",
+				);
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/demo.app/demo";
 			};
@@ -631,10 +647,14 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 				);
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = demo;
 			};
 			name = Debug;
@@ -647,10 +667,14 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 				);
 				INFOPLIST_FILE = demo/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
-				OTHER_LDFLAGS = "-ObjC";
+				OTHER_LDFLAGS = (
+					"-ObjC",
+					"-lc++",
+				);
 				PRODUCT_NAME = demo;
 			};
 			name = Release;
@@ -693,6 +717,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -733,6 +758,7 @@
 					"$(inherited)",
 					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
 					"$(SRCROOT)/../node_modules/react-native/React/**",
+					"$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/**",
 				);
 				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/demo/ios/demo/AppDelegate.m
+++ b/demo/ios/demo/AppDelegate.m
@@ -9,7 +9,16 @@
 
 #import "AppDelegate.h"
 
+#import "Orientation.h"
 #import "RCTRootView.h"
+
+@implementation AppDelegate (Orientation)
+
+- (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+  return [Orientation getOrientation];
+}
+
+@end
 
 @implementation AppDelegate
 
@@ -47,6 +56,7 @@
                                                       moduleName:@"demo"
                                                initialProperties:nil
                                                    launchOptions:launchOptions];
+  rootView.backgroundColor = [[UIColor alloc] initWithRed:1.0f green:1.0f blue:1.0f alpha:1];
 
   self.window = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
   UIViewController *rootViewController = [UIViewController new];

--- a/demo/ios/demo/AppDelegate.m
+++ b/demo/ios/demo/AppDelegate.m
@@ -12,15 +12,11 @@
 #import "Orientation.h"
 #import "RCTRootView.h"
 
-@implementation AppDelegate (Orientation)
+@implementation AppDelegate
 
 - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
   return [Orientation getOrientation];
 }
-
-@end
-
-@implementation AppDelegate
 
 - (BOOL)application:(UIApplication *)application didFinishLaunchingWithOptions:(NSDictionary *)launchOptions
 {

--- a/demo/ios/demoTests/demoTests.m
+++ b/demo/ios/demoTests/demoTests.m
@@ -13,7 +13,7 @@
 #import "RCTLog.h"
 #import "RCTRootView.h"
 
-#define TIMEOUT_SECONDS 240
+#define TIMEOUT_SECONDS 600
 #define TEXT_TO_LOOK_FOR @"Welcome to React Native!"
 
 @interface demoTests : XCTestCase

--- a/demo/package.json
+++ b/demo/package.json
@@ -3,11 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "start": "react-native start"
+    "start": "node_modules/react-native/packager/packager.sh"
   },
   "dependencies": {
-    "react": "^0.14.8",
-    "react-native": "^0.24.1",
-    "react-native-orientation": "^1.16.0"
+    "react": "^15.1.0",
+    "react-native": "^0.27.2",
+    "react-native-orientation": ".."
   }
 }

--- a/iOS/RCTOrientation.xcodeproj/project.pbxproj
+++ b/iOS/RCTOrientation.xcodeproj/project.pbxproj
@@ -1,0 +1,260 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 46;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		27F5D7F01D0BC955003F92DE /* Orientation.m in Sources */ = {isa = PBXBuildFile; fileRef = 27F5D7EF1D0BC955003F92DE /* Orientation.m */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		58B511D91A9E6C8500147676 /* CopyFiles */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "include/$(PRODUCT_NAME)";
+			dstSubfolderSpec = 16;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		134814201AA4EA6300B7C361 /* libRCTOrientation.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = libRCTOrientation.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		27F5D7EE1D0BC955003F92DE /* Orientation.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Orientation.h; sourceTree = "<group>"; };
+		27F5D7EF1D0BC955003F92DE /* Orientation.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = Orientation.m; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		58B511D81A9E6C8500147676 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		134814211AA4EA7D00B7C361 /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				134814201AA4EA6300B7C361 /* libRCTOrientation.a */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		27F5D7ED1D0BC820003F92DE /* RCTOrientation */ = {
+			isa = PBXGroup;
+			children = (
+				27F5D7EE1D0BC955003F92DE /* Orientation.h */,
+				27F5D7EF1D0BC955003F92DE /* Orientation.m */,
+			);
+			path = RCTOrientation;
+			sourceTree = "<group>";
+		};
+		58B511D21A9E6C8500147676 = {
+			isa = PBXGroup;
+			children = (
+				27F5D7ED1D0BC820003F92DE /* RCTOrientation */,
+				134814211AA4EA7D00B7C361 /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		58B511DA1A9E6C8500147676 /* RCTOrientation */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RCTOrientation" */;
+			buildPhases = (
+				58B511D71A9E6C8500147676 /* Sources */,
+				58B511D81A9E6C8500147676 /* Frameworks */,
+				58B511D91A9E6C8500147676 /* CopyFiles */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RCTOrientation;
+			productName = RCTDataManager;
+			productReference = 134814201AA4EA6300B7C361 /* libRCTOrientation.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		58B511D31A9E6C8500147676 /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				LastUpgradeCheck = 0610;
+				ORGANIZATIONNAME = Facebook;
+				TargetAttributes = {
+					58B511DA1A9E6C8500147676 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
+				};
+			};
+			buildConfigurationList = 58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RCTOrientation" */;
+			compatibilityVersion = "Xcode 3.2";
+			developmentRegion = English;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+			);
+			mainGroup = 58B511D21A9E6C8500147676;
+			productRefGroup = 58B511D21A9E6C8500147676;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				58B511DA1A9E6C8500147676 /* RCTOrientation */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXSourcesBuildPhase section */
+		58B511D71A9E6C8500147676 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				27F5D7F01D0BC955003F92DE /* Orientation.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		58B511ED1A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+			};
+			name = Debug;
+		};
+		58B511EE1A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
+				CLANG_CXX_LIBRARY = "libc++";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = YES;
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu99;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 7.0;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				SDKROOT = iphoneos;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		58B511F01A9E6C8500147676 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RCTOrientation;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		58B511F11A9E6C8500147676 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/include,
+					"$(SRCROOT)/../../React/**",
+					"$(SRCROOT)/../../react-native/React/**",
+				);
+				LIBRARY_SEARCH_PATHS = "$(inherited)";
+				OTHER_LDFLAGS = "-ObjC";
+				PRODUCT_NAME = RCTOrientation;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		58B511D61A9E6C8500147676 /* Build configuration list for PBXProject "RCTOrientation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511ED1A9E6C8500147676 /* Debug */,
+				58B511EE1A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		58B511EF1A9E6C8500147676 /* Build configuration list for PBXNativeTarget "RCTOrientation" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				58B511F01A9E6C8500147676 /* Debug */,
+				58B511F11A9E6C8500147676 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 58B511D31A9E6C8500147676 /* Project object */;
+}

--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -5,8 +5,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 #import "RCTBridgeModule.h"
-#import "RCTBridge.h"
-#import "RCTEventDispatcher.h"
 
 @interface Orientation : NSObject <RCTBridgeModule>
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -3,9 +3,9 @@
 //
 
 #import "Orientation.h"
+#import "RCTEventDispatcher.h"
 
 @implementation Orientation
-
 @synthesize bridge = _bridge;
 
 static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllButUpsideDown;
@@ -33,10 +33,10 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"specificOrientationDidChange"
+  [self.bridge.eventDispatcher sendDeviceEventWithName:@"specificOrientationDidChange"
                                               body:@{@"specificOrientation": [self getSpecificOrientationStr:orientation]}];
 
-  [_bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange"
+  [self.bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange"
                                               body:@{@"orientation": [self getOrientationStr:orientation]}];
 
 }
@@ -185,4 +185,3 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
 }
 
 @end
-

--- a/package.json
+++ b/package.json
@@ -25,5 +25,13 @@
   "bugs": {
     "url": "https://github.com/yamill/react-native-orientation/issues"
   },
-  "homepage": "https://github.com/yamill/react-native-orientation#readme"
+  "homepage": "https://github.com/yamill/react-native-orientation#readme",
+  "rnpm": {
+    "android": {
+      "packageInstance": "new OrientationPackage(this)"
+    },
+    "ios": {
+      "project": "iOS/RCTOrientation.xcodeproj"
+    }
+  }
 }

--- a/react-native-orientation.podspec
+++ b/react-native-orientation.podspec
@@ -1,0 +1,22 @@
+require 'json'
+
+package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
+
+Pod::Spec.new do |s|
+  s.name           = package['name']
+  s.version        = package['version']
+  s.summary        = package['description']
+  s.description    = package['description']
+  s.license        = package['license']
+  s.author         = package['author']
+  s.homepage       = package['homepage']
+  s.source         = { :git => 'https://github.com/yamill/react-native-orientation.git', :tag => s.version }
+
+  s.requires_arc   = true
+  s.platform       = :ios, '7.0'
+
+  s.preserve_paths = 'README.md', 'package.json', 'index.js'
+  s.source_files   = 'RCTOrientation/*.{h,m}'
+
+  s.dependency 'React'
+end

--- a/react-native-orientation.podspec
+++ b/react-native-orientation.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.platform       = :ios, '7.0'
 
   s.preserve_paths = 'README.md', 'package.json', 'index.js'
-  s.source_files   = 'RCTOrientation/*.{h,m}'
+  s.source_files   = 'iOS/RCTOrientation/*.{h,m}'
 
   s.dependency 'React'
 end


### PR DESCRIPTION
Supercedes #66, #74

- Add support for CocoaPods (Closes #49)
- Add support for rnpm (Closes #59)
- Update demo to support react-native >=0.25 (Closes #69, Closes #71)

I've done some pretty exhaustive testing of the different installation options, but I would love some additional feedback.

@JAStanton I pulled in your changes to the podspec (other than the name), and your commits to remove AppDelegate from the library files.  Hope that's cool.

@nevir Could you comment on this implementation and whether or not it could cause any problems like those mentioned in #66?