### PR TITLE
Fix swift cocoapods use_frameworks! import

### DIFF
--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -4,7 +4,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#import "RCTBridgeModule.h"
+#import <React/RCTBridgeModule.h>
 
 @interface Orientation : NSObject <RCTBridgeModule>
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;

--- a/react-native-orientation.podspec
+++ b/react-native-orientation.podspec
@@ -19,4 +19,5 @@ Pod::Spec.new do |s|
   s.source_files   = 'iOS/RCTOrientation/*.{h,m}'
 
   s.dependency 'React'
+  s.module_name = "ReactNativeOrientation"
 end


### PR DESCRIPTION
I use swift in react native main project, and i used use_frameworks! in my Podfile.
But then i can't build project, and these changes fixed me.
Anyone have better ideas on swift project like me?

No bridging header which is not work for me. Need to import React and ReactNativeOrientation (module_name)

``` swift
import React
import ReactNativeOrientation

@UIApplicationMain
class AppDelegate: UIResponder, UIApplicationDelegate {
  func application(application: UIApplication, supportedInterfaceOrientationsForWindow window: UIWindow?) -> UIInterfaceOrientationMask {
    return Orientation.getOrientation()
  }
```
