### PR TITLE
Support react-native 0.29

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ project.xcworkspace
 #
 node_modules/
 npm-debug.log
+*.iml

--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ Consult the React Native documentation on how to [install React Native using Coc
     }
     ```
 
-3. Register module (in MainActivity.java)
+3. Register module (in MainApplication.java)
 
     ```
     import com.github.yamill.orientation.OrientationPackage;  // <--- import
 
-    public class MainActivity extends ReactActivity {
+    public class MainApplication extends Application implements ReactApplication {
       ......
 
       @Override
       protected List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
               new MainReactPackage(),
-              new OrientationPackage(this)      <------- Add this
+              new OrientationPackage()      <------- Add this
           );
       }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile "com.facebook.react:react-native:+"
 }

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -30,8 +30,6 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
     public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
-
-
         final ReactApplicationContext ctx = reactContext;
 
         receiver = new BroadcastReceiver() {
@@ -46,12 +44,12 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 params.putString("orientation", orientationValue);
                 if (ctx.hasActiveCatalystInstance()) {
                     ctx
-                        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-                        .emit("orientationDidChange", params);
+                    .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                    .emit("orientationDidChange", params);
                 }
             }
         };
-	ctx.addLifecycleEventListener(this);
+        ctx.addLifecycleEventListener(this);
     }
 
     @Override
@@ -66,72 +64,82 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         String orientation = this.getOrientationString(orientationInt);
 
         if (orientation == "null") {
-          callback.invoke(orientationInt, null);
+            callback.invoke(orientationInt, null);
         } else {
-          callback.invoke(null, orientation);
+            callback.invoke(null, orientation);
         }
     }
 
     @ReactMethod
     public void lockToPortrait() {
-        final Activity mActivity = getCurrentActivity();
-        if (mActivity == null) return;
-      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
 
     @ReactMethod
     public void lockToLandscape() {
-        final Activity mActivity = getCurrentActivity();
-        if (mActivity == null) return;
-      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
 
     @ReactMethod
     public void lockToLandscapeLeft() {
-        final Activity mActivity = getCurrentActivity();
-        if (mActivity == null) return;
-      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     }
 
     @ReactMethod
     public void lockToLandscapeRight() {
-        final Activity mActivity = getCurrentActivity();
-        if (mActivity == null) return;
-      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
     }
 
     @ReactMethod
     public void unlockAllOrientations() {
-        final Activity mActivity = getCurrentActivity();
-        if (mActivity == null) return;
-      mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
+        final Activity activity = getCurrentActivity();
+        if (activity == null) {
+            return;
+        }
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
     }
 
     @Override
     public @Nullable Map<String, Object> getConstants() {
-      HashMap<String, Object> constants = new HashMap<String, Object>();
-      int orientationInt = getReactApplicationContext().getResources().getConfiguration().orientation;
+        HashMap<String, Object> constants = new HashMap<String, Object>();
+        int orientationInt = getReactApplicationContext().getResources().getConfiguration().orientation;
 
-      String orientation = this.getOrientationString(orientationInt);
-      if (orientation == "null") {
-        constants.put("initialOrientation", null);
-      } else {
-        constants.put("initialOrientation", orientation);
-      }
+        String orientation = this.getOrientationString(orientationInt);
+        if (orientation == "null") {
+            constants.put("initialOrientation", null);
+        } else {
+            constants.put("initialOrientation", orientation);
+        }
 
-      return constants;
+        return constants;
     }
 
     private String getOrientationString(int orientation) {
-      if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
-          return "LANDSCAPE";
-      } else if (orientation == Configuration.ORIENTATION_PORTRAIT) {
-          return "PORTRAIT";
-      } else if (orientation == Configuration.ORIENTATION_UNDEFINED) {
-          return "UNKNOWN";
-      } else {
-          return "null";
-      }
+        if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
+            return "LANDSCAPE";
+        } else if (orientation == Configuration.ORIENTATION_PORTRAIT) {
+            return "PORTRAIT";
+        } else if (orientation == Configuration.ORIENTATION_UNDEFINED) {
+            return "UNKNOWN";
+        } else {
+            return "null";
+        }
     }
 
     @Override
@@ -165,4 +173,4 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         catch (java.lang.IllegalArgumentException e) {
             FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
         }}
-}
+    }

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -8,9 +8,6 @@ import android.content.IntentFilter;
 import android.content.pm.ActivityInfo;
 import android.content.res.Configuration;
 import android.util.Log;
-import java.util.HashMap;
-import java.util.Map;
-import javax.annotation.Nullable;
 
 import com.facebook.common.logging.FLog;
 import com.facebook.react.bridge.Arguments;
@@ -23,17 +20,21 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.common.ReactConstants;
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
-public class OrientationModule extends ReactContextBaseJavaModule {
-    final private Activity mActivity;
+import java.util.HashMap;
+import java.util.Map;
 
-    public OrientationModule(ReactApplicationContext reactContext, final Activity activity) {
+import javax.annotation.Nullable;
+
+public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
+    final BroadcastReceiver receiver;
+
+    public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
 
-        mActivity = activity;
 
         final ReactApplicationContext ctx = reactContext;
 
-        final BroadcastReceiver receiver = new BroadcastReceiver() {
+        receiver = new BroadcastReceiver() {
             @Override
             public void onReceive(Context context, Intent intent) {
                 Configuration newConfig = intent.getParcelableExtra("newConfig");
@@ -51,38 +52,6 @@ public class OrientationModule extends ReactContextBaseJavaModule {
             }
         };
 
-        activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
-
-        LifecycleEventListener listener = new LifecycleEventListener() {
-            @Override
-            public void onHostResume() {
-                activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
-            }
-
-            @Override
-            public void onHostPause() {
-                try
-                {
-                    activity.unregisterReceiver(receiver);
-                }
-                catch (java.lang.IllegalArgumentException e) {
-                    FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
-                }
-            }
-
-            @Override
-            public void onHostDestroy() {
-                try
-                {
-                    activity.unregisterReceiver(receiver);
-                }
-                catch (java.lang.IllegalArgumentException e) {
-                    FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
-                }
-            }
-        };
-
-        reactContext.addLifecycleEventListener(listener);
     }
 
     @Override
@@ -105,26 +74,36 @@ public class OrientationModule extends ReactContextBaseJavaModule {
 
     @ReactMethod
     public void lockToPortrait() {
+        final Activity mActivity = getCurrentActivity();
+        if (mActivity == null) return;
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
     }
 
     @ReactMethod
     public void lockToLandscape() {
+        final Activity mActivity = getCurrentActivity();
+        if (mActivity == null) return;
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR_LANDSCAPE);
     }
 
     @ReactMethod
     public void lockToLandscapeLeft() {
+        final Activity mActivity = getCurrentActivity();
+        if (mActivity == null) return;
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE);
     }
 
     @ReactMethod
     public void lockToLandscapeRight() {
+        final Activity mActivity = getCurrentActivity();
+        if (mActivity == null) return;
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_REVERSE_LANDSCAPE);
     }
 
     @ReactMethod
     public void unlockAllOrientations() {
+        final Activity mActivity = getCurrentActivity();
+        if (mActivity == null) return;
       mActivity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
     }
 
@@ -154,4 +133,36 @@ public class OrientationModule extends ReactContextBaseJavaModule {
           return "null";
       }
     }
+
+    @Override
+    public void onHostResume() {
+        final Activity activity = getCurrentActivity();
+
+        assert activity != null;
+        activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
+    }
+    @Override
+    public void onHostPause() {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) return;
+        try
+        {
+            activity.unregisterReceiver(receiver);
+        }
+        catch (java.lang.IllegalArgumentException e) {
+            FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
+        }
+    }
+
+    @Override
+    public void onHostDestroy() {
+        final Activity activity = getCurrentActivity();
+        if (activity == null) return;
+        try
+        {
+            activity.unregisterReceiver(receiver);
+        }
+        catch (java.lang.IllegalArgumentException e) {
+            FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
+        }}
 }

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -51,7 +51,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
                 }
             }
         };
-
+	ctx.addLifecycleEventListener(this);
     }
 
     @Override

--- a/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
@@ -1,7 +1,5 @@
 package com.github.yamill.orientation;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -13,16 +11,14 @@ import java.util.Collections;
 import java.util.List;
 
 public class OrientationPackage implements ReactPackage {
-    private Activity mCurrentActivity;
 
-    public OrientationPackage(Activity activity) {
-        mCurrentActivity = activity;
+    public OrientationPackage() {
     }
 
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-            new OrientationModule(reactContext, mCurrentActivity)
+            new OrientationModule(reactContext)
         );
     }
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   "homepage": "https://github.com/yamill/react-native-orientation#readme",
   "rnpm": {
     "android": {
-      "packageInstance": "new OrientationPackage(this)"
+      "packageInstance": "new OrientationPackage()"
     },
     "ios": {
       "project": "iOS/RCTOrientation.xcodeproj"


### PR DESCRIPTION
Since [RN 0.29](https://github.com/facebook/react-native/releases/tag/v0.29.0), getPackages() is defined in MainApplication, so modules's constructors can't have access to the activity. It's now required to call `getCurrentActivity()` from ReactContextBaseJavaModule whenever the activity is needed.

As the activity is attached to the context in `onResume`, OrientationModule also need to implement LifecycleEventListener to be able to call `activity.registerReceiver`

This pull request would close #83 