### PR TITLE
Fix bug when some listeners can have the same keys

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,21 @@ var listeners = {};
 var orientationDidChangeEvent = "orientationDidChange";
 var specificOrientationDidChangeEvent = "specificOrientationDidChange";
 
+var id = 0;
+var META = '__listener_id';
+
+function getKey(listener){
+  if (!listener.hasOwnProperty(META)){
+    if (!Object.isExtensible(listener)) {
+      return 'F';
+    }
+    Object.defineProperty(listener, META, {
+      value: 'L' + ++id,
+    });
+  }
+  return listener[META];
+};
+
 module.exports = {
   getOrientation(cb) {
     Orientation.getOrientation((error,orientation) =>{
@@ -32,30 +47,34 @@ module.exports = {
     Orientation.unlockAllOrientations();
   },
   addOrientationListener(cb) {
-    listeners[cb] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
+    var key = getKey(cb);
+    listeners[key] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
       (body) => {
         cb(body.orientation);
       });
   },
   removeOrientationListener(cb) {
-    if (!listeners[cb]) {
+    var key = getKey(cb);
+    if (!listeners[key]) {
       return;
     }
-    listeners[cb].remove();
-    listeners[cb] = null;
+    listeners[key].remove();
+    listeners[key] = null;
   },
   addSpecificOrientationListener(cb) {
-    listeners[cb] = DeviceEventEmitter.addListener(specificOrientationDidChangeEvent,
+    var key = getKey(cb);
+    listeners[key] = DeviceEventEmitter.addListener(specificOrientationDidChangeEvent,
       (body) => {
         cb(body.specificOrientation);
       });
   },
   removeSpecificOrientationListener(cb) {
-    if (!listeners[cb]) {
+    var key = getKey(cb);
+    if (!listeners[key]) {
       return;
     }
-    listeners[cb].remove();
-    listeners[cb] = null;
+    listeners[key].remove();
+    listeners[key] = null;
   },
   getInitialOrientation() {
     return Orientation.initialOrientation;


### PR DESCRIPTION
Fixes https://github.com/yamill/react-native-orientation/issues/88

Added function for generating uniq key for a listener and storing it in the listener hidden property.

Note: this realization inspired from the implementation of the Map from [core-js](https://github.com/zloirock/core-js/blob/v2.4.1/modules/es6.map.js): https://github.com/zloirock/core-js/blob/master/modules/_meta.js#L18-L30 
There is another approach we can store listeners refs in array and use push, indexOf, splice, but it might be not performant for cases with many listeners.