### PR TITLE
Updating code to be able to handle newest versions of react native

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,19 +53,19 @@ Consult the React Native documentation on how to [install React Native using Coc
     }
     ```
 
-3. Register module (in MainActivity.java)
+3. Register module (in MainApplication.java)
 
     ```
     import com.github.yamill.orientation.OrientationPackage;  // <--- import
 
-    public class MainActivity extends ReactActivity {
+    public class MainApplication extends Application implements ReactApplication {
       ......
 
       @Override
       protected List<ReactPackage> getPackages() {
           return Arrays.<ReactPackage>asList(
               new MainReactPackage(),
-              new OrientationPackage(this)      <------- Add this
+              new OrientationPackage()      <------- Add this
           );
       }
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.20.+'
+    compile 'com.facebook.react:react-native:0.31.+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.11.+'
+    compile 'com.facebook.react:react-native:0.20.+'
 }

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -26,10 +26,10 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 public class OrientationModule extends ReactContextBaseJavaModule {
     final private Activity mActivity;
 
-    public OrientationModule(ReactApplicationContext reactContext, final Activity activity) {
+    public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
 
-        mActivity = activity;
+        mActivity = getCurrentActivity();
 
         final ReactApplicationContext ctx = reactContext;
 
@@ -51,19 +51,19 @@ public class OrientationModule extends ReactContextBaseJavaModule {
             }
         };
 
-        activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
+        mActivity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
 
         LifecycleEventListener listener = new LifecycleEventListener() {
             @Override
             public void onHostResume() {
-                activity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
+                mActivity.registerReceiver(receiver, new IntentFilter("onConfigurationChanged"));
             }
 
             @Override
             public void onHostPause() {
                 try
                 {
-                    activity.unregisterReceiver(receiver);
+                    mActivity.unregisterReceiver(receiver);
                 }
                 catch (java.lang.IllegalArgumentException e) {
                     FLog.e(ReactConstants.TAG, "receiver already unregistered", e);
@@ -74,7 +74,7 @@ public class OrientationModule extends ReactContextBaseJavaModule {
             public void onHostDestroy() {
                 try
                 {
-                    activity.unregisterReceiver(receiver);
+                    mActivity.unregisterReceiver(receiver);
                 }
                 catch (java.lang.IllegalArgumentException e) {
                     FLog.e(ReactConstants.TAG, "receiver already unregistered", e);

--- a/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
@@ -1,7 +1,5 @@
 package com.github.yamill.orientation;
 
-import android.app.Activity;
-
 import com.facebook.react.ReactPackage;
 import com.facebook.react.bridge.JavaScriptModule;
 import com.facebook.react.bridge.NativeModule;
@@ -13,16 +11,10 @@ import java.util.Collections;
 import java.util.List;
 
 public class OrientationPackage implements ReactPackage {
-    private Activity mCurrentActivity;
-
-    public OrientationPackage(Activity activity) {
-        mCurrentActivity = activity;
-    }
-
     @Override
     public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
         return Arrays.<NativeModule>asList(
-            new OrientationModule(reactContext, mCurrentActivity)
+            new OrientationModule(reactContext)
         );
     }
 


### PR DESCRIPTION
As you can see, I made few changes to handle the newest react native version. According to the react native documentation, packages should no more be managed in Activity but in Application. Also, we cannot give an activity to the constructor any more 'cause it is now handled in Application but the ReactContextBaseJavaModule class provides a method to get the Activity.

Friendly