### PR TITLE
use status bar orientation info when the device orientation returns Unknown

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -58,7 +58,25 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
       break;
 
     default:
-      orientationStr = @"UNKNOWN";
+      // orientation is unknown, we try to get the status bar orientation
+      switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+        case UIInterfaceOrientationPortrait:
+          orientationStr = @"PORTRAIT";
+          break;
+        case UIInterfaceOrientationLandscapeLeft:
+        case UIInterfaceOrientationLandscapeRight:
+
+          orientationStr = @"LANDSCAPE";
+          break;
+
+        case UIInterfaceOrientationPortraitUpsideDown:
+          orientationStr = @"PORTRAITUPSIDEDOWN";
+          break;
+
+        default:
+          orientationStr = @"UNKNOWN";
+          break;
+      }
       break;
   }
   return orientationStr;
@@ -84,7 +102,25 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
       break;
 
     default:
-      orientationStr = @"UNKNOWN";
+      // orientation is unknown, we try to get the status bar orientation
+      switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+        case UIInterfaceOrientationPortrait:
+          orientationStr = @"PORTRAIT";
+          break;
+        case UIInterfaceOrientationLandscapeLeft:
+        case UIInterfaceOrientationLandscapeRight:
+
+          orientationStr = @"LANDSCAPE";
+          break;
+
+        case UIInterfaceOrientationPortraitUpsideDown:
+          orientationStr = @"PORTRAITUPSIDEDOWN";
+          break;
+
+        default:
+          orientationStr = @"UNKNOWN";
+          break;
+      }
       break;
   }
   return orientationStr;


### PR DESCRIPTION
With this PR, the status bar orientation is queried and returned when the device orientation returns Unknown. No more Unknown orientations provided to deviceOrientationDidChange callbacks...
