### PR TITLE
Adding initialSpecificOrientation support

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -178,9 +178,11 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
 
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
   NSString *orientationStr = [self getOrientationStr:orientation];
+  NSString *orientationSpecificStr = [self getSpecificOrientationStr:orientation];
 
   return @{
-    @"initialOrientation": orientationStr
+    @"initialOrientation": orientationStr,
+    @"initialSpecificOrientation": orientationSpecificStr
   };
 }
 

--- a/index.js
+++ b/index.js
@@ -78,5 +78,8 @@ module.exports = {
   },
   getInitialOrientation() {
     return Orientation.initialOrientation;
+  },
+  getInitialSpecificOrientation() {
+    return Orientation.initialSpecificOrientation;
   }
 }


### PR DESCRIPTION
The initialOrientation support is useful, but my app depends on the Specific orientation so I added a method that exposes that as well.