### PR TITLE
Fix can't find RCTBridgeModule.h for RN 0.40 and higher

### DIFF
--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -4,7 +4,12 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
+
+#ifdef __has_include(<React/RCTBridgeModule.h>)
+#import <React/RCTBridgeModule.h>
+#else
 #import "RCTBridgeModule.h"
+#endif
 
 @interface Orientation : NSObject <RCTBridgeModule>
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;


### PR DESCRIPTION
Thanks to https://github.com/yamill/react-native-orientation/issues/159#issuecomment-287311619