### PR TITLE
hotfix: resolving incorrect ifdef syntax for imports iOS

### DIFF
--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -4,7 +4,7 @@
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
-#ifdef __has_include(<React/RCTBridgeModule.h>)
+#if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
 #else
 #import "RCTBridgeModule.h"

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -3,7 +3,7 @@
 //
 
 #import "Orientation.h"
-#ifdef __has_include(<React/RCTEventDispatcher.h>)
+#if __has_include(<React/RCTEventDispatcher.h>)
 #import <React/RCTEventDispatcher.h>
 #else
 #import "RCTEventDispatcher.h.h"


### PR DESCRIPTION
@stoneman1 can you check that this is the correct syntax? This could be the reason why users using RN <0.40 were facing issues. #154 also uses this approach. Works fine for me. Can you double check, squash and merge?