### PR TITLE
Feature/add screen size notification option

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,6 +195,12 @@ removeOrientationListener((orientation) => {});
 addOrientationWithScreenSizeListener((notification) => {});
 ```
 
+Often React Native's `Dimensions.get('window')` width and height values are not correct for the new orientation at the moment when the orientation listeners are triggered. 
+
+This listener will return orientation, screenWidth and screenHeight when orientation changes. The screen width/height are from the native OS rather than what React Native reports.
+
+Use it if you need to re-layout your UI for the new orientation when you are using dimension values relative to the screen's width/height. i.e. Centering a dynamically-sized modal in a view.
+
 `notification` will return:
 - `orientation` with one of the following values:
   - `LANDSCAPE`

--- a/README.md
+++ b/README.md
@@ -192,6 +192,23 @@ removeOrientationListener((orientation) => {});
 ```
 
 ```javascript
+addOrientationWithScreenSizeListener((notification) => {});
+```
+
+`notification` will return:
+- `orientation` with one of the following values:
+  - `LANDSCAPE`
+  - `PORTRAIT`
+  - `PORTRAITUPSIDEDOWN`
+  - `UNKNOWN`
+- `screenWidth` with the screen's width in points (iOS) or dp (Android).
+- `screenHeight` with the screen's height in points (iOS) or dp (Android).
+
+```javascript
+removeOrientationWithScreenSizeListener((notification) => {});
+```
+
+```javascript
 addSpecificOrientationListener((specificOrientation) => {});
 ```
 

--- a/README.md
+++ b/README.md
@@ -201,8 +201,8 @@ addOrientationWithScreenSizeListener((notification) => {});
   - `PORTRAIT`
   - `PORTRAITUPSIDEDOWN`
   - `UNKNOWN`
-- `screenWidth` with the screen's width in points (iOS) or dp (Android).
-- `screenHeight` with the screen's height in points (iOS) or dp (Android).
+- `screenWidth` with the screen's width for the new orientation in points (iOS)/dp (Android).
+- `screenHeight` with the screen's height for the new orientation in points (iOS)/dp (Android).
 
 ```javascript
 removeOrientationWithScreenSizeListener((notification) => {});

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -42,6 +42,8 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
 
                 WritableMap params = Arguments.createMap();
                 params.putString("orientation", orientationValue);
+                params.putInt("screenWidth", newConfig.screenWidthDp);
+                params.putInt("screenHeight", newConfig.screenHeightDp);
                 if (ctx.hasActiveCatalystInstance()) {
                     ctx
                     .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)

--- a/index.js
+++ b/index.js
@@ -74,6 +74,23 @@ module.exports = {
     listeners[key] = null;
   },
 
+  addOrientationWithScreenSizeListener(cb) {
+    var key = getKey(cb);
+    listeners[key] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
+      (body) => {
+        cb(body);
+      });
+  },
+
+  removeOrientationWithScreenSizeListener(cb) {
+    var key = getKey(cb);
+    if (!listeners[key]) {
+      return;
+    }
+    listeners[key].remove();
+    listeners[key] = null;
+  },
+
   addSpecificOrientationListener(cb) {
     var key = getKey(cb);
 


### PR DESCRIPTION
Often React Native's `Dimensions.get('window')` width and height values are not correct for the new orientation at the moment when the orientation listeners are triggered. 

This listener will return orientation, screenWidth and screenHeight when orientation changes. The screen width/height are from the native OS rather than what React Native reports.

Use it if you need to re-layout your UI for the new orientation when you are using dimension values relative to the screen's width/height. i.e. Centering a dynamically-sized modal in a view.