### PR TITLE
Remove depreciated createJSModules @overide marker

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationPackage.java
@@ -22,7 +22,7 @@ public class OrientationPackage implements ReactPackage {
         );
     }
 
-    @Override
+    // Deprecated RN 0.47
     public List<Class<? extends JavaScriptModule>> createJSModules() {
         return Collections.emptyList();
     }


### PR DESCRIPTION
[`createJSModules` is now not required on Android](https://github.com/facebook/react-native/commit/ce6fb337a146e6f261f2afb564aa19363774a7a8) from RN 0.47. I actually can't build an app on RN 0.47 without removing this method/@ovveride marker.