### PR TITLE
Update README to emphasis configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ npm install react-native-orientation --save
 react-native link react-native-orientation
 ```
 
+Please note that you **still need to manually configure** a couple files even when using automatic linking. Please see the ['Configuration'](#configuration) section below. You will also **need to restart your simulator** before the package will work properly.
+
 ### Manual Linking
 
 **iOS**


### PR DESCRIPTION
It seems like a lot of issues might be solved by simply emphasizing the need to manually configure even when using automatic linking (e.g. https://github.com/yamill/react-native-orientation/issues/136#issuecomment-271053249 and [issues related to 'not locking'](https://github.com/yamill/react-native-orientation/issues?utf8=%E2%9C%93&q=is%3Aissue%20not%20locking)) as well as needing to restart the simulator (e.g. [issues related to 'undefined'](https://github.com/yamill/react-native-orientation/issues?utf8=%E2%9C%93&q=is%3Aissue%20undefined))