### PR TITLE
added requiresMainQueueSetup with RN 0.49+ requirement when constantsToExport overridden

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -224,4 +224,9 @@ RCT_EXPORT_METHOD(unlockAllOrientations)
   };
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+    return YES;
+}
+
 @end


### PR DESCRIPTION
fixes #235