### PR TITLE
Support iOS app extensions

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -5,8 +5,10 @@
 #import "Orientation.h"
 #if __has_include(<React/RCTEventDispatcher.h>)
 #import <React/RCTEventDispatcher.h>
+#import <React/RCTUtils.h>
 #else
 #import "RCTEventDispatcher.h"
+#import "RCTUtils.h"
 #endif
 
 @implementation Orientation
@@ -63,7 +65,7 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
 
     default:
       // orientation is unknown, we try to get the status bar orientation
-      switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+      switch ([RCTSharedApplication() statusBarOrientation]) {
         case UIInterfaceOrientationPortrait:
           orientationStr = @"PORTRAIT";
           break;
@@ -107,7 +109,7 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
 
     default:
       // orientation is unknown, we try to get the status bar orientation
-      switch ([[UIApplication sharedApplication] statusBarOrientation]) {
+      switch ([RCTSharedApplication() statusBarOrientation]) {
         case UIInterfaceOrientationPortrait:
           orientationStr = @"PORTRAIT";
           break;


### PR DESCRIPTION
Currently apps won't compile if you want to use `react-native-orientation` in combination with an App Extension.

This change, which was introduced to lots of React core libraries, allows the library to operate within an App Extension.