### PR TITLE
Fix "cannot find "orientation.h" error

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Please note that you **still need to manually configure** a couple files even wh
 **iOS**
 
 1. Add `node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj` to your xcode project, usually under the `Libraries` group
-1. Add `libRCTOrientation.a` (from `Products` under `RCTOrientation.xcodeproj`) to build target's `Linked Frameworks and Libraries` list
+2. Add `libRCTOrientation.a` (from `Products` under `RCTOrientation.xcodeproj`) to build target's `Linked Frameworks and Libraries` list
+3. Add `$(SRCROOT)/node_modules/react-native-orientation/iOS/RCTOrientation/` to `Project Name` -> `Build Settings` -> `Header Search Paths`
 
 
 **Android**


### PR DESCRIPTION
When manually linking react-native-orientation for iOS, an extra step is needed otherwise it'll show `cannot find "orientation.h" error - 

Add `$(SRCROOT)/node_modules/react-native-orientation/iOS/RCTOrientation/` to `Project Name` -> `Build Settings` -> `Header Search Paths`