### PR TITLE
Add requiresMainQueueSetup to fix warning in RN 0.49+

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -34,6 +34,11 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
   [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
++ (BOOL)requiresMainQueueSetup
+{
+  return YES;
+}
+
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];


### PR DESCRIPTION
Please see [this](https://github.com/wix/react-native-navigation/issues/1982) for reference.