### PR TITLE
Fix Manual Header Search Path Addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please note that you **still need to manually configure** a couple files even wh
 
 1. Add `node_modules/react-native-orientation/iOS/RCTOrientation.xcodeproj` to your xcode project, usually under the `Libraries` group
 2. Add `libRCTOrientation.a` (from `Products` under `RCTOrientation.xcodeproj`) to build target's `Linked Frameworks and Libraries` list
-3. Add `$(SRCROOT)/node_modules/react-native-orientation/iOS/RCTOrientation/` to `Project Name` -> `Build Settings` -> `Header Search Paths`
+3. Add `$(SRCROOT)/../node_modules/react-native-orientation/iOS/RCTOrientation/` to `Project Name` -> `Build Settings` -> `Header Search Paths`
 
 
 **Android**


### PR DESCRIPTION
Automatic linking failed for me. RTCOrientation.xcodeproj didn't appear in my Libraries. I'm using .xcworkspace.

I linked manually, but it still failed. All of the other paths in Header Search Paths started with `$(SRCROOT)/../node_modules`, so I added `/..` to the header search path of RCTOrientation. Then it built. I suppose this is a README typo.