### PR TITLE
remove deprecated sendDeviceEventWithName

### DIFF
--- a/iOS/RCTOrientation/Orientation.h
+++ b/iOS/RCTOrientation/Orientation.h
@@ -6,11 +6,13 @@
 #import <UIKit/UIKit.h>
 #if __has_include(<React/RCTBridgeModule.h>)
 #import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 #else
 #import "RCTBridgeModule.h"
+#import "RCTEventEmitter.h"
 #endif
 
-@interface Orientation : NSObject <RCTBridgeModule>
+@interface Orientation : RCTEventEmitter <RCTBridgeModule>
 + (void)setOrientation: (UIInterfaceOrientationMask)orientation;
 + (UIInterfaceOrientationMask)getOrientation;
 @end

--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -42,11 +42,9 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
 - (void)deviceOrientationDidChange:(NSNotification *)notification
 {
   UIDeviceOrientation orientation = [[UIDevice currentDevice] orientation];
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"specificOrientationDidChange"
-                                              body:@{@"specificOrientation": [self getSpecificOrientationStr:orientation]}];
+  [self sendEventWithName:@"specificOrientationDidChange" body:@{@"specificOrientation": [self getSpecificOrientationStr:orientation]}];
 
-  [self.bridge.eventDispatcher sendDeviceEventWithName:@"orientationDidChange"
-                                              body:@{@"orientation": [self getOrientationStr:orientation]}];
+  [self sendEventWithName:@"orientationDidChange" body:@{@"orientation": [self getOrientationStr:orientation]}];
 
 }
 

--- a/index.js
+++ b/index.js
@@ -1,5 +1,9 @@
 var Orientation = require('react-native').NativeModules.Orientation;
 var DeviceEventEmitter = require('react-native').DeviceEventEmitter;
+var NativeEventEmitter = require('react-native').NativeEventEmitter;
+var Platform = require('react-native').Platform;
+
+var OrientationEmitter = new NativeEventEmitter(Orientation);
 
 var listeners = {};
 var orientationDidChangeEvent = 'orientationDidChange';
@@ -56,11 +60,20 @@ module.exports = {
   },
 
   addOrientationListener(cb) {
-    var key = getKey(cb);
-    listeners[key] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
-      (body) => {
-        cb(body.orientation);
-      });
+    if (Platform.OS === 'ios') {
+      var key = getKey(cb);
+
+      listeners[key] = OrientationEmitter.addListener(orientationDidChangeEvent,
+        (body) => {
+          cb(body.orientation);
+        });
+    } else {
+      var key = getKey(cb);
+      listeners[key] = DeviceEventEmitter.addListener(orientationDidChangeEvent,
+        (body) => {
+          cb(body.orientation);
+        });
+    }
   },
 
   removeOrientationListener(cb) {
@@ -75,12 +88,21 @@ module.exports = {
   },
 
   addSpecificOrientationListener(cb) {
-    var key = getKey(cb);
+    if (Platform.OS === 'ios') {
+      var key = getKey(cb);
 
-    listeners[key] = DeviceEventEmitter.addListener(specificOrientationDidChangeEvent,
-      (body) => {
-        cb(body.specificOrientation);
-      });
+      listeners[key] = OrientationEmitter.addListener(specificOrientationDidChangeEvent,
+        (body) => {
+          cb(body.orientation);
+        });
+    } else {
+      var key = getKey(cb);
+
+      listeners[key] = DeviceEventEmitter.addListener(specificOrientationDidChangeEvent,
+        (body) => {
+          cb(body.specificOrientation);
+        });
+    }
   },
 
   removeSpecificOrientationListener(cb) {


### PR DESCRIPTION
### Issue
iOS throws the warning: 
```
'sendDeviceEventWithName:body:' is deprecated: Subclass RCTEventEmitter instead
```

### Solution
With this PR, I have removed that warning and upgraded to the [recommended way of emitting events](https://facebook.github.io/react-native/docs/native-modules-ios.html#sending-events-to-javascript), and added the appropriate platform check in index.js

There should be no changes to actual usage of the library. Purely a removal of deprecated code.