### PR TITLE
Fixes indention of OrientationModule.java

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -168,5 +168,5 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     @Override
     public void onHostDestroy() {
 
-        }
     }
+}


### PR DESCRIPTION
Noticed that these last two parentheses were not indented properly so I fixed them. 