### PR TITLE
Added the "GetSpecificOrientation" method back into Android implementation

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -27,13 +27,14 @@ import javax.annotation.Nullable;
 
 public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
     final BroadcastReceiver receiver;
+    final private ReactApplicationContext ctx;
     private static final int ORIENTATION_0 = 0;
     private static final int ORIENTATION_90 = 3;
     private static final int ORIENTATION_270 = 1;
 
     public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
-        final ReactApplicationContext ctx = reactContext;
+        ctx = reactContext;
 
         receiver = new BroadcastReceiver() {
             @Override
@@ -75,8 +76,8 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
     
     @ReactMethod
     public void getSpecificOrientation(Callback callback) {
-        Display display = ((WindowManager)
-                mReactContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+        android.view.Display display = ((android.view.WindowManager)
+                ctx.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
         int screenOrientation = display.getRotation();
         String specifOrientationValue = getSpecificOrientationString(screenOrientation);
 

--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -27,6 +27,9 @@ import javax.annotation.Nullable;
 
 public class OrientationModule extends ReactContextBaseJavaModule implements LifecycleEventListener{
     final BroadcastReceiver receiver;
+    private static final int ORIENTATION_0 = 0;
+    private static final int ORIENTATION_90 = 3;
+    private static final int ORIENTATION_270 = 1;
 
     public OrientationModule(ReactApplicationContext reactContext) {
         super(reactContext);
@@ -67,6 +70,20 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
             callback.invoke(orientationInt, null);
         } else {
             callback.invoke(null, orientation);
+        }
+    }
+    
+    @ReactMethod
+    public void getSpecificOrientation(Callback callback) {
+        Display display = ((WindowManager)
+                mReactContext.getSystemService(Context.WINDOW_SERVICE)).getDefaultDisplay();
+        int screenOrientation = display.getRotation();
+        String specifOrientationValue = getSpecificOrientationString(screenOrientation);
+
+        if (specifOrientationValue == "null") {
+            callback.invoke(screenOrientation, null);
+        } else {
+            callback.invoke(null, specifOrientationValue);
         }
     }
 
@@ -140,6 +157,24 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         } else {
             return "null";
         }
+    }
+    
+    private String getSpecificOrientationString(int screenOrientation) {
+        String specifOrientationValue = "UNKNOWN";
+        switch (screenOrientation)
+        {
+            default:
+            case ORIENTATION_0: // Portrait
+                specifOrientationValue = "PORTRAIT";
+                break;
+            case ORIENTATION_90: // Landscape right
+                specifOrientationValue = "LANDSCAPE-RIGHT";
+                break;
+            case ORIENTATION_270: // Landscape left
+                specifOrientationValue = "LANDSCAPE-LEFT";
+                break;
+        }
+        return specifOrientationValue;
     }
 
     @Override


### PR DESCRIPTION
I needed to use the GetSpecificOrientation method on Android and I noticed that it was removed back in March 2016. I just added it back in with some minor changes because of the changes to the "master" branch since back then in 2016.