### PR TITLE
Set Android unlockAllOrientations to use SCREEN_ORIENTATION_FULL_USER

### DIFF
--- a/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
+++ b/android/src/main/java/com/github/yamill/orientation/OrientationModule.java
@@ -112,7 +112,7 @@ public class OrientationModule extends ReactContextBaseJavaModule implements Lif
         if (activity == null) {
             return;
         }
-        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_SENSOR);
+        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_FULL_USER);
     }
 
     @Override


### PR DESCRIPTION
With this SCREEN_ORIENTATION_FULL_USER we allow any of the 4 possible screen orientations. Added in API level 18.
We have a bug when we use current unlock method version.
Previous code version don't handle situation if user has lock for portrait orientation in his device preferences.
