### PR TITLE
Changed android/build.gradle to use rootProject variables

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,16 +5,22 @@ def _ext = rootProject.ext
 /* 
     If you want to change this properties, just put them on your android/buil.gradle like this:
 
-    ...
+    buildscript {
+        ...
+    }
+
+    ext {
+        versionCode = 13
+        versionName = "1.9.3"
+        compileSdkVersion = 26
+        minSdkVersion = 16
+        targetSdkVersion = 23
+        buildToolsVersion = "26.0.2"
+        supportLibVersion = "26.0.2"
+        googlePlayServicesVersion = "11.4.2"
+    }
+
     allprojects {
-        project.ext {
-            compileSdkVersion = YOUR_COMPILE_SDK_VERSION
-            buildToolsVersion = YOUR_BUILD_TOOLS_VERSION
-            minSdkVersion = YOUR_SDK_VERSION
-            targetSdkVersion = YOUR_TARGET_SDK_VERSION
-            versionCode = YOUR_VERSION_CODE
-            versionName = YOUR_VERSION_NAME
-        }
         ...
     }
 */

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,36 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+/* 
+    If you want to change this properties, just put them on your android/buil.gradle like this:
+
+    ...
+    allprojects {
+        project.ext {
+            compileSdkVersion = YOUR_COMPILE_SDK_VERSION
+            buildToolsVersion = YOUR_BUILD_TOOLS_VERSION
+            minSdkVersion = YOUR_SDK_VERSION
+            targetSdkVersion = YOUR_TARGET_SDK_VERSION
+            versionCode = YOUR_VERSION_CODE
+            versionName = YOUR_VERSION_NAME
+        }
+        ...
+    }
+*/
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 23
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '23.0.1'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 23
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -16,5 +40,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    compile "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
Now is possible to use rootProject variables to set some build.gradle configurations like compileSdkVersion, targetSdkVersion and others.