### PR TITLE
Changed read me - added an optional config step for IOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ Add the following to your project's `AppDelegate.m`:
   // ...
 
 - (UIInterfaceOrientationMask)application:(UIApplication *)application supportedInterfaceOrientationsForWindow:(UIWindow *)window {
+
+
+  // this loop is used to prevent repainting of view before rotation is complete
+  while ([[UIDevice currentDevice] isGeneratingDeviceOrientationNotifications]) {
+        [[UIDevice currentDevice] endGeneratingDeviceOrientationNotifications];
+  }
+  
+  
   return [Orientation getOrientation];
 }
   


### PR DESCRIPTION
When forcing orientation for a specific page, by locking orientation, the view would render before the orientation animation was complete. This would cause issues where you may get a landscape view when locking to portrait from landscape or vice versa. 