### PR TITLE
Update build.gradle for RN 0.57

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,42 @@
 apply plugin: 'com.android.library'
 
+def _ext = rootProject.ext
+
+/* 
+    If you want to change this properties, just put them on your android/build.gradle like this:
+
+    buildscript {
+        ...
+    }
+
+    ext {
+        versionCode = 13
+        versionName = "1.9.3"
+        compileSdkVersion = 27
+        minSdkVersion = 16
+        targetSdkVersion = 27
+        buildToolsVersion = "27.0.3"
+        supportLibVersion = "27.1.0"
+        googlePlayServicesVersion = "11.4.2"
+    }
+
+    allprojects {
+        ...
+    }
+*/
+def _reactNativeVersion = _ext.has('reactNative') ? _ext.reactNative : '+'
+def _compileSdkVersion = _ext.has('compileSdkVersion') ? _ext.compileSdkVersion : 27
+def _buildToolsVersion = _ext.has('buildToolsVersion') ? _ext.buildToolsVersion : '27.0.3'
+def _minSdkVersion = _ext.has('minSdkVersion') ? _ext.minSdkVersion : 16
+def _targetSdkVersion = _ext.has('targetSdkVersion') ? _ext.targetSdkVersion : 27
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion _compileSdkVersion
+    buildToolsVersion _buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion _minSdkVersion
+        targetSdkVersion _targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {
@@ -16,5 +46,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:${_reactNativeVersion}"
 }


### PR DESCRIPTION
React Native 0.57 will [scaffold new projects using Gradle 3, instead of Gradle 2](https://github.com/facebook/react-native/commit/6eac2d4e2f5f697043b495002872bfac3e8595cb).

Users who install this library with Gradle 3 will see the following error:

```
Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
```

This PR fixes this warning.

Please note: this will cause any users who are still on Gradle 2 to see an error:

```
> Could not find method implementation() for arguments [com.facebook.react:react-native:+] on object of type org.gradle.api.internal.artifacts.dsl.dependencies.DefaultDependencyHandler.
```

This is because `implementation` is only available for users of Gradle 3.

It may therefore be worth bumping the major version of this lib to indicate a breaking change for some users.