### PR TITLE
Adds missing react peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "android"
   ],
   "peerDependencies": {
-    "react-native": ">=0.40"
+    "react-native": ">=0.40",
+    "react": "*"
   },
   "author": "Yamill Vallecillo <yamill@gmail.com> (github.com/yamill)",
   "contributors": [


### PR DESCRIPTION
The `react-native` package has peer dependencies on `react`, which means that `react-native-orientation` also depends on it.