### PR TITLE
Return specific orientation on fallback too (iOS)

### DIFF
--- a/iOS/RCTOrientation/Orientation.m
+++ b/iOS/RCTOrientation/Orientation.m
@@ -117,9 +117,11 @@ static UIInterfaceOrientationMask _orientation = UIInterfaceOrientationMaskAllBu
           orientationStr = @"PORTRAIT";
           break;
         case UIInterfaceOrientationLandscapeLeft:
+          orientationStr = @"LANDSCAPE-LEFT";
+          break;
         case UIInterfaceOrientationLandscapeRight:
 
-          orientationStr = @"LANDSCAPE";
+          orientationStr = @"LANDSCAPE-RIGHT";
           break;
 
         case UIInterfaceOrientationPortraitUpsideDown:


### PR DESCRIPTION
In the fallback, on iOS, it would not return device specific landscape orientation. This fixes that.