### PR TITLE
Moved package.json's rnpm config to react-native.config.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,13 +35,5 @@
   "bugs": {
     "url": "https://github.com/yamill/react-native-orientation/issues"
   },
-  "homepage": "https://github.com/yamill/react-native-orientation#readme",
-  "rnpm": {
-    "android": {
-      "packageInstance": "new OrientationPackage()"
-    },
-    "ios": {
-      "project": "iOS/RCTOrientation.xcodeproj"
-    }
-  }
+  "homepage": "https://github.com/yamill/react-native-orientation#readme"
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+    project: {
+        ios: {
+            project: 'iOS/RCTOrientation.xcodeproj',
+        },
+        android: {
+            "packageInstance": "new OrientationPackage()"
+        }
+    },
+};


### PR DESCRIPTION
This is going to be required in the release after RN 0.60. I think I did this the right way, although someone else should probably take a look. This closes #352 