### PR TITLE
get SDK version from root directory

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,16 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 23)
+    buildToolsVersion safeExtGet('buildToolsVersion', "23.0.1")
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        targetSdkVersion safeExtGet('targetSdkVersion', 22) 
         versionCode 1
         versionName "1.0"
         ndk {


### PR DESCRIPTION
building the release app failed with this error: 
```
\node_modules\react-native-orientation\android\build\intermediates\res\merged\release\values\values.xml:2919: error: resource android:attr/offset not found.
```

increasing the sdk versions of this library solved the issue for me.
This PR tries to get the sdk version from the root project, and in case of error, falls back to older default values.

Also it is good to be compatible with the root project of the users.