### PR TITLE
Fix build error caused by this package and supports auto linking

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,12 +1,15 @@
 apply plugin: 'com.android.library'
 
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
+}
+
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion safeExtGet('compileSdkVersion', 28)
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 22
+        minSdkVersion safeExtGet('minSdkVersion', 16)
+        targetSdkVersion safeExtGet('targetSdkVersion', 28)
         versionCode 1
         versionName "1.0"
         ndk {

--- a/package.json
+++ b/package.json
@@ -35,13 +35,5 @@
   "bugs": {
     "url": "https://github.com/yamill/react-native-orientation/issues"
   },
-  "homepage": "https://github.com/yamill/react-native-orientation#readme",
-  "rnpm": {
-    "android": {
-      "packageInstance": "new OrientationPackage()"
-    },
-    "ios": {
-      "project": "iOS/RCTOrientation.xcodeproj"
-    }
-  }
+  "homepage": "https://github.com/yamill/react-native-orientation#readme"
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,10 @@
+module.exports = {
+  rnpm: {
+    "android": {
+      "packageInstance": "new OrientationPackage()"
+    },
+    "ios": {
+      "project": "iOS/RCTOrientation.xcodeproj"
+    }
+  }
+};


### PR DESCRIPTION
- Fix Build error
>Task :react-native-orientation:verifyReleaseResources FAILED
FAILURE: Build failed with an exception.
Execution failed for task ':react-native-orientation:verifyReleaseResources'.

- Supports autolinking