### PR TITLE
Fix: replace depricated `compile` call

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
This PR should fix this error:
```
> Configure project :react-native-orientation
WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed in version 5.0 of the Android Gradle plugin.
For more information, see http://d.android.com/r/tools/update-dependency-configurations.html.
```