### PR TITLE
added compatibility for Gradle 7.0.0+ on React Native 0.68.1

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile "com.facebook.react:react-native:+"
+    implementation "com.facebook.react:react-native:+"
 }


### PR DESCRIPTION
Added this "implementation "com.facebook.react:react-native:+"" as a change in build.gradle